### PR TITLE
Instantiate child Test Cases from a Test Suite

### DIFF
--- a/js/test-management-scenarios/utils.js
+++ b/js/test-management-scenarios/utils.js
@@ -26,3 +26,28 @@ exports.resetStatuses = function(testRun, testRunCopy) {
    testRunCopy.fields['Number of failed test cases'] = 0;
   return true; 
 };
+
+// Create a test case execution.
+exports.createTestCaseExecution = function(workflow, ctx, testRun, testCase) {
+  var message = '<a href="' + testCase.url + '"> ' + testCase.id + '</a>';
+  workflow.check((testCase.Type.name == ctx.Type.TestCase.name) || (testCase.Type.name == ctx.Type.TestSuite.name), workflow.i18n('\'Test Run\' can be linked to \'Test Case\' and \'Test Suite\' only, but {0} has \'{1}\' type!', message, testCase.Type.name));
+  testCase.links[ctx.Execution.inward].delete(testRun);
+
+  // New issue creation 
+  var testCaseExecution = testCase.copy();
+  testCaseExecution.Type = ctx.Type.TestExecution.name;
+  testCaseExecution.Status = ctx.Status.NoRun.name;
+
+  // Remove all links from Test Case Execution       
+  Object.keys(testCaseExecution.links).forEach(function(linkType) {
+    if (!testCaseExecution.links[linkType])
+      return;
+    testCaseExecution.links[linkType].clear();
+  });
+  testCaseExecution.summary = "[TEST_CASE_EXECUTION" + "] [" + testCaseExecution.summary + "]";
+
+  // Links population 
+  testCaseExecution.links[ctx.Subtask.inward].add(testRun);
+  testRun.links[ctx.Subtask.outward].add(testCaseExecution);
+  testCaseExecution.links[ctx.Execution.outward].add(testCase);
+};


### PR DESCRIPTION
As per the issue raised at #25 I have modified the workflow so that when a `Test Suite` is added to a `Test Run` all `Test Cases that are subtasks of the `Test Suite` will be turned in to `Test Case Executions`