### PR TITLE
Created directory recursively before creating write stream

### DIFF
--- a/js/script/zip.js
+++ b/js/script/zip.js
@@ -4,6 +4,7 @@ var process = require('process');
 var archiver = require('archiver');
 
 function zipFolder(srcFolder, zipFilePath) {
+  fs.mkdirSync(path.dirname(zipFilePath), { recursive: true });
   var output = fs.createWriteStream(zipFilePath);
   var zipArchive = archiver('zip');
   


### PR DESCRIPTION
In case you do not want to store binaries in your repository (.zip files) and do not have a zips folder, the script fails with a file not found error, because the parent directory doesn't exist